### PR TITLE
circular=false in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ fc = FoldCompound("GGGGGAAAAACCCCCC";
                   params=:RNA_Turner2004,
                   temperature=37u"°C",
                   uniq_ML=true,
-                  circular=true)
+                  circular=false)
 ```
 
 Important keyword arguments


### PR DESCRIPTION
The expected output

```julia
# please excuse the excess precision printed when displaying -9.4 kcal/mol
mfe(fc)  # => ("(((((.....))))).", -9.399999618530273 kcal mol^-1)
```

needs `circular=false`.